### PR TITLE
Fixes for four items identified in review of #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,7 @@ include erlang.mk
 
 # After deps are fetched, strip lz4 and zstd from leveled's OTP application
 # dependency list so they are never started. See comment above DEPS for why.
-deps:: patch-leveled-app
-
-patch-leveled-app:
+autopatch-leveled::
 	$(verbose) if [ -f $(DEPS_DIR)/leveled/ebin/leveled.app ]; then \
 		erl -noshell -eval 'F = "$(DEPS_DIR)/leveled/ebin/leveled.app", {ok, [{application, Name, Props}]} = file:consult(F), Apps = proplists:get_value(applications, Props, []), Apps2 = Apps -- [lz4, zstd], case Apps2 =:= Apps of true -> ok; false -> Props2 = lists:keystore(applications, 1, Props, {applications, Apps2}), ok = file:write_file(F, io_lib:format("~tp.~n", [{application, Name, Props2}])) end' -s init stop; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ deps:: patch-leveled-app
 
 patch-leveled-app:
 	$(verbose) if [ -f $(DEPS_DIR)/leveled/ebin/leveled.app ]; then \
-		sed -i 's/,zstd//' $(DEPS_DIR)/leveled/ebin/leveled.app; \
-		sed -i 's/,lz4//' $(DEPS_DIR)/leveled/ebin/leveled.app; \
+		erl -noshell -eval 'F = "$(DEPS_DIR)/leveled/ebin/leveled.app", {ok, [{application, Name, Props}]} = file:consult(F), Apps = proplists:get_value(applications, Props, []), Apps2 = Apps -- [lz4, zstd], case Apps2 =:= Apps of true -> ok; false -> Props2 = lists:keystore(applications, 1, Props, {applications, Apps2}), ok = file:write_file(F, io_lib:format("~tp.~n", [{application, Name, Props2}])) end' -s init stop; \
 	fi
 
 benchmarks: test-build

--- a/src/rabbit_delayed_message_leveled.erl
+++ b/src/rabbit_delayed_message_leveled.erl
@@ -124,10 +124,20 @@ delete(DelayTS) ->
             end
     end.
 
-delete_index(DeliveryTS) ->
+delete_index(DelayTS) ->
     case ets:whereis(?INDEX_TABLE) of
-        undefined -> ok;
-        _ -> ets:delete(?INDEX_TABLE, DeliveryTS)
+        undefined ->
+            ok;
+        _ ->
+            case ets:first(?INDEX_TABLE) of
+                '$end_of_table' ->
+                    ok;
+                {FirstDelay, _Key} = IndexEntry when FirstDelay =:= DelayTS ->
+                    ets:delete(?INDEX_TABLE, IndexEntry),
+                    delete_index(DelayTS);
+                _ ->
+                    ok
+            end
     end.
 
 make_key(DelayTS) ->

--- a/src/rabbit_delayed_message_m2k_converter.erl
+++ b/src/rabbit_delayed_message_m2k_converter.erl
@@ -13,19 +13,21 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("rabbit_delayed_message.hrl").
 
--export([init_copy_to_khepri/4,
+-export([init_copy_to_khepri/3,
          copy_to_khepri/3,
          delete_from_khepri/3]).
 
+-record(?MODULE, {}).
+
 -define(BUCKET, <<"x-delayed-messages">>).
 
--spec init_copy_to_khepri(StoreId, MigrationId, Tables, State) -> Ret when
+-spec init_copy_to_khepri(StoreId, MigrationId, Tables) -> Ret when
       StoreId :: khepri:store_id(),
       MigrationId :: mnesia_to_khepri:migration_id(),
       Tables :: [mnesia_to_khepri:mnesia_table()],
-      State :: rabbit_db_m2k_converter:state(),
-      Ret :: {ok, State}.
-init_copy_to_khepri(_StoreId, _MigrationId, Tables, State) ->
+      Ret :: {ok, Priv},
+      Priv :: #?MODULE{}.
+init_copy_to_khepri(_StoreId, _MigrationId, Tables) ->
     ?LOG_DEBUG(
        "Mnesia->Leveled init: tables ~0p",
        [Tables],
@@ -42,7 +44,7 @@ init_copy_to_khepri(_StoreId, _MigrationId, Tables, State) ->
     %% until khepri_db is fully enabled (i.e. after all data has been copied)
     %% before calling setup() and resetting the timer.
     rabbit_delayed_message:await_khepri_and_setup(),
-    {ok, State}.
+    {ok, #?MODULE{}}.
 
 -spec copy_to_khepri(Table, Record, State) -> Ret when
       Table :: mnesia_to_khepri:mnesia_table(),

--- a/src/rabbit_delayed_message_m2k_converter.erl
+++ b/src/rabbit_delayed_message_m2k_converter.erl
@@ -13,21 +13,19 @@
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include("rabbit_delayed_message.hrl").
 
--export([init_copy_to_khepri/3,
+-export([init_copy_to_khepri/4,
          copy_to_khepri/3,
          delete_from_khepri/3]).
 
--record(?MODULE, {}).
-
 -define(BUCKET, <<"x-delayed-messages">>).
 
--spec init_copy_to_khepri(StoreId, MigrationId, Tables) -> Ret when
+-spec init_copy_to_khepri(StoreId, MigrationId, Tables, State) -> Ret when
       StoreId :: khepri:store_id(),
       MigrationId :: mnesia_to_khepri:migration_id(),
       Tables :: [mnesia_to_khepri:mnesia_table()],
-      Ret :: {ok, Priv},
-      Priv :: #?MODULE{}.
-init_copy_to_khepri(_StoreId, _MigrationId, Tables) ->
+      State :: rabbit_db_m2k_converter:state(),
+      Ret :: {ok, State}.
+init_copy_to_khepri(_StoreId, _MigrationId, Tables, State) ->
     ?LOG_DEBUG(
        "Mnesia->Leveled init: tables ~0p",
        [Tables],
@@ -44,7 +42,7 @@ init_copy_to_khepri(_StoreId, _MigrationId, Tables) ->
     %% until khepri_db is fully enabled (i.e. after all data has been copied)
     %% before calling setup() and resetting the timer.
     rabbit_delayed_message:await_khepri_and_setup(),
-    {ok, #?MODULE{}}.
+    {ok, State}.
 
 -spec copy_to_khepri(Table, Record, State) -> Ret when
       Table :: mnesia_to_khepri:mnesia_table(),

--- a/src/rabbit_delayed_message_m2k_converter.erl
+++ b/src/rabbit_delayed_message_m2k_converter.erl
@@ -15,8 +15,7 @@
 
 -export([init_copy_to_khepri/3,
          copy_to_khepri/3,
-         delete_from_khepri/3,
-         clear_data_in_khepri/1]).
+         delete_from_khepri/3]).
 
 -record(?MODULE, {}).
 
@@ -97,13 +96,6 @@ copy_to_khepri(Table, Record, _State) ->
 %% migration window closes.
 delete_from_khepri(_Table, _Key, State) ->
     {ok, State}.
-
-clear_data_in_khepri(Table) ->
-    ?LOG_DEBUG(
-       "Mnesia->Leveled clear_data_in_khepri: table ~0p",
-       [Table],
-       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
-    ok.
 
 %% Named for debugging: trace this function to observe backpressure events
 %% during migration.

--- a/src/rabbit_delayed_message_m2k_converter.erl
+++ b/src/rabbit_delayed_message_m2k_converter.erl
@@ -6,7 +6,7 @@
 %%
 -module(rabbit_delayed_message_m2k_converter).
 
--behaviour(rabbit_db_m2k_converter).
+-behaviour(mnesia_to_khepri_converter).
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").

--- a/src/rabbit_delayed_message_m2k_converter.erl
+++ b/src/rabbit_delayed_message_m2k_converter.erl
@@ -6,7 +6,7 @@
 %%
 -module(rabbit_delayed_message_m2k_converter).
 
--behaviour(mnesia_to_khepri_converter).
+-behaviour(rabbit_db_m2k_converter).
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("khepri_mnesia_migration/src/kmm_logging.hrl").


### PR DESCRIPTION
## Summary

Four small, independently-reviewable fixes for issues identified while reviewing PR #2 ("Migrate from Mnesia to Leveled"). The full review is at https://gist.github.com/lukebakken/ee1d50ae268010a3e8fa17f7ce614f53/47cabc0e62fe08bafdd651d984336355a5ce76df.

1. c2c980a `patch-leveled-app`: replace the two non-portable `sed -i` calls with a single `erl -noshell -eval` invocation. The old form fails on BSD/macOS sed because in-place editing requires `-i ''`. The new form is term-aware, only rewrites the file when the `applications` list actually changes, and leaves the file byte-identical otherwise.
2. c42c1aa `test/plugin_SUITE.erl`: remove the duplicate `init_per_group(mnesia_to_khepri, Config)` clause. The two clauses had identical patterns, so Erlang warns "this clause cannot match because a previous clause at line N always matches" and only the first clause ever ran. The retained clause is the one with `{tcp_ports_base, 21200}`, consistent with the other broker-starting groups.
3. e11e90d `rabbit_delayed_message_m2k_converter`: remove the dead `clear_data_in_khepri/1` function and its export. The `mnesia_to_khepri_converter` behaviour this module implements does not declare such a callback, the `khepri_mnesia_migration` library never invokes it, `rabbit_khepri` does not invoke it, and no local caller exists in this module.
4. 2ce3df4 `rabbit_delayed_message_leveled:delete_index/1`: the old body called `ets:delete(?INDEX_TABLE, DeliveryTS)` with a bare integer. The ETS `ordered_set` index is keyed by `{DelayTS, Key}` tuples, so the delete never matched and the call was silently a no-op. The Mnesia backend's `delete_index/1` correctly removes the index rows for a delay, so the two backends diverged. In the normal delivery flow `get_many/2` already removes the matching ETS entries, so the bug is masked; it only surfaces on the recovery path invoked when `get_many/1` returns `[]` for a fired timer. The fix mirrors the loop pattern already used by `delete/1` and `get_many/2`.

All four commits are independent and can be cherry-picked individually. None of them change runtime behaviour except #4, which changes a no-op into a correct cleanup in the recovery path.

## What was tested

- #1: verified end-to-end by running a stripped-down Makefile with the new recipe against sample `leveled.app` files both with and without `lz4`/`zstd` in the `applications` list; confirmed it strips both, is idempotent, and is byte-identical when there is nothing to strip.
- #2: confirmed with a minimal reproduction that Erlang's compiler warns on duplicate clauses and dispatches to the first. Re-parsed the resulting file with `epp_dodger` to confirm a single clause remains.
- #3: grepped the entire rabbitmq-server tree (including `deps/khepri_mnesia_migration` and `deps/rabbit`) to confirm zero external callers. Re-parsed the resulting file with `epp_dodger` to confirm it still has exactly the four intended functions (three behaviour callbacks plus one private helper).
- #4: exercised the fixed `delete_index/1` against a freshly-populated ETS `ordered_set` with the production `{DelayTS, BinKey}` tuple-key shape across four scenarios (matching entries, non-matching TS, last-entry, empty-table). All four pass.

## Not addressed here

Follow-up PRs to address additional items from the review will be forthcoming. The two unfixed critical bugs are storage leak after delivery and `messages_delayed/1` only incrementing, both in the leveled backend. See the linked review for the full list.
